### PR TITLE
tinyproxy: convert to use alpine now that it supports reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/v
 Use *--add-host* to specify the local address of the hawkBit container:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:192.168.1.10 --name tinyproxy linarotechnologies/tinyproxy:latest-arm64
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:192.168.1.10 --name tinyproxy linarotechnologies/tinyproxy:latest-arm64
 ```
 
 ### Mosquitto MQTT Broker

--- a/tinyproxy/Dockerfile
+++ b/tinyproxy/Dockerfile
@@ -1,6 +1,6 @@
-FROM bitnami/minideb:unstable
+FROM alpine:edge
 
-RUN install_packages tinyproxy
+RUN apk add --no-cache tinyproxy
 
 # Tinyproxy config file (use Debian location currently)
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
@@ -12,4 +12,4 @@ RUN chmod +x start.sh
 ENTRYPOINT ["/start.sh"]
 
 # Default to dump service log
-CMD tail -f /var/log/tinyproxy/tinyproxy.log
+CMD /usr/sbin/tinyproxy -d -c /etc/tinyproxy/tinyproxy.conf

--- a/tinyproxy/Dockerfile.arm64
+++ b/tinyproxy/Dockerfile.arm64
@@ -1,6 +1,6 @@
-FROM linarotechnologies/minideb:stretch-arm64
+FROM linarotechnologies/alpine:edge-arm64
 
-RUN install_packages tinyproxy
+RUN apk add --no-cache tinyproxy
 
 # Tinyproxy config file (use Debian location currently)
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
@@ -12,4 +12,4 @@ RUN chmod +x start.sh
 ENTRYPOINT ["/start.sh"]
 
 # Default to dump service log
-CMD tail -f /var/log/tinyproxy/tinyproxy.log
+CMD /usr/sbin/tinyproxy -d -c /etc/tinyproxy/tinyproxy.conf

--- a/tinyproxy/Dockerfile.armhf
+++ b/tinyproxy/Dockerfile.armhf
@@ -1,6 +1,6 @@
-FROM linarotechnologies/minideb:stretch-armhf
+FROM linarotechnologies/alpine:edge-armhf
 
-RUN install_packages tinyproxy
+RUN apk add --no-cache tinyproxy
 
 # Tinyproxy config file (use Debian location currently)
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
@@ -12,4 +12,4 @@ RUN chmod +x start.sh
 ENTRYPOINT ["/start.sh"]
 
 # Default to dump service log
-CMD tail -f /var/log/tinyproxy/tinyproxy.log
+CMD /usr/sbin/tinyproxy -d -c /etc/tinyproxy/tinyproxy.conf

--- a/tinyproxy/README.md
+++ b/tinyproxy/README.md
@@ -9,7 +9,7 @@ docker build -t tinyproxy --force-rm -f Dockerfile<.arm64/.armhf> .
 ## Run the container
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy tinyproxy
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy tinyproxy
 ```
 
 ## Run the pre-built container
@@ -17,17 +17,17 @@ docker run --restart=always -d -t --net=host --read-only --tmpfs=/run --tmpfs=/v
 AMD64:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy
 ```
 
 ARM64:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest-arm64
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest-arm64
 ```
 
 ARMHF:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest-armhf
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest-armhf
 ```

--- a/tinyproxy/start.sh
+++ b/tinyproxy/start.sh
@@ -6,7 +6,8 @@ mkdir -p /var/log/tinyproxy
 touch /var/log/tinyproxy/tinyproxy.log
 chown -R tinyproxy:tinyproxy /var/log/tinyproxy /var/run/tinyproxy
 
-/usr/sbin/tinyproxy -c /etc/tinyproxy/tinyproxy.conf
+# Force dump of tinyproxy.log to stdout
+tail -f /var/log/tinyproxy/tinyproxy.log &
 
 # Execute all the rest
 exec "$@"


### PR DESCRIPTION
From ~50MB (minideb) to ~6.5MB (alpine).

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>