### PR TITLE
mosquitto: move mosquitto from entrypoint to cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Create a local mosquitto configuration file:
 ```
 $ cat ~/mosquitto.conf
 # General settings
-log_dest file /var/log/mosquitto/mosquitto.log
+log_dest stdout
 
 # Bridge configuration
 connection #connection-name
 address #url:#port
-remote_username #username 
+remote_username #username
 remote_password #password
 try_private false
 start_type automatic
@@ -77,5 +77,5 @@ topic iotdevice-1/type/+/id/# out 1 "" ""
 Start the container:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/log -v /home/linaro/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-arm64
+docker run --restart=always -d -t --net=host --read-only -v /home/linaro/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-arm64
 ```

--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -8,5 +8,4 @@ COPY start.sh start.sh
 RUN chmod +x start.sh
 ENTRYPOINT ["/start.sh"]
 
-# Default to dump service log
-CMD tail -f /var/log/mosquitto/mosquitto.log
+CMD /usr/sbin/mosquitto -c /etc/mosquitto/conf.d/mosquitto.conf

--- a/mosquitto/Dockerfile.arm64
+++ b/mosquitto/Dockerfile.arm64
@@ -8,5 +8,4 @@ COPY start.sh start.sh
 RUN chmod +x start.sh
 ENTRYPOINT ["/start.sh"]
 
-# Default to dump service log
-CMD tail -f /var/log/mosquitto/mosquitto.log
+CMD /usr/sbin/mosquitto -c /etc/mosquitto/conf.d/mosquitto.conf

--- a/mosquitto/Dockerfile.armhf
+++ b/mosquitto/Dockerfile.armhf
@@ -8,5 +8,4 @@ COPY start.sh start.sh
 RUN chmod +x start.sh
 ENTRYPOINT ["/start.sh"]
 
-# Default to dump service log
-CMD tail -f /var/log/mosquitto/mosquitto.log
+CMD /usr/sbin/mosquitto -c /etc/mosquitto/conf.d/mosquitto.conf

--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -13,14 +13,14 @@ Create a local mosquitto config file with generic credentials and relevant chann
 ```
 connection #connection-name
 address #url:#port
-remote_username #username 
+remote_username #username
 remote_password #password
 try_private false
 start_type automatic
 bridge_attempt_unsubscribe false
 notifications false
 connection_messages true
-log_dest file /var/log/mosquitto/mosquitto.log
+log_dest stdout
 
 # Device management subscriptions
 topic iotdm-1/type/+/id/# in 1 "" ""
@@ -39,7 +39,7 @@ topic iotdevice-1/type/+/id/# out 1 "" ""
 Then run the containiner volume mounting your mosquitto config file:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/log -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto mosquitto
+docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto mosquitto
 ```
 
 ## Run the pre-built container
@@ -47,17 +47,17 @@ docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/log -v /pa
 AMD64:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/log -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto
+docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto
 ```
 
 ARM64:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/log -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-arm64
+docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-arm64
 ```
 
 ARMHF:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/log -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-armhf
+docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-armhf
 ```

--- a/mosquitto/etc-mosquitto-template.conf
+++ b/mosquitto/etc-mosquitto-template.conf
@@ -1,13 +1,13 @@
 connection #connection-name
 address #url:#port
-remote_username #username 
+remote_username #username
 remote_password #password
 try_private false
 start_type automatic
 bridge_attempt_unsubscribe false
 notifications false
 connection_messages true
-log_dest file /var/log/mosquitto/mosquitto.log
+log_dest stdout
 
 # Device management subscriptions
 topic iotdm-1/type/+/id/# in 1 "" ""

--- a/mosquitto/start.sh
+++ b/mosquitto/start.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
 
-# Make sure the log path permission is correct
-mkdir -p /var/log/mosquitto
-chown mosquitto:mosquitto /var/log/mosquitto
-
-/usr/sbin/mosquitto -c /etc/mosquitto/conf.d/mosquitto.conf -d
-
 # Execute all the rest
 exec "$@"


### PR DESCRIPTION
Via CMD docker can track the execution status of the command, aborting
or restarting the container in case of errors with mosquitto.

Also changed default log output to stdout, so it can be stored as part
of the container log.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>