### PR TITLE
RFC: Use image manifests to abstract architecture specific images

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ USE_WL=0
 Start the container:
 
 ```
-docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/var/run --tmpfs=/var/lock --tmpfs=/var/log -v /home/linaro/bluetooth_6lowpand.conf:/etc/bluetooth/bluetooth_6lowpand.conf --name bt-joiner linarotechnologies/bt-joiner:latest-arm64
+docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/var/run --tmpfs=/var/lock --tmpfs=/var/log -v /home/linaro/bluetooth_6lowpand.conf:/etc/bluetooth/bluetooth_6lowpand.conf --name bt-joiner linarotechnologies/bt-joiner:latest
 ```
 
 ### Tinyproxy (IPv6 -> IPv4)
@@ -33,7 +33,7 @@ docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/v
 Use *--add-host* to specify the local address of the hawkBit container:
 
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:192.168.1.10 --name tinyproxy linarotechnologies/tinyproxy:latest-arm64
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:192.168.1.10 --name tinyproxy linarotechnologies/tinyproxy:latest
 ```
 
 ### Mosquitto MQTT Broker
@@ -55,7 +55,7 @@ GW_DEVICE_TYPE=hikey
 Start the container:
 
 ```
-docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix-mosquitto.env --name ibm-bluemix-mosquitto linarotechnologies/ibm-bluemix-mosquitto:latest-arm64
+docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix-mosquitto.env --name ibm-bluemix-mosquitto linarotechnologies/ibm-bluemix-mosquitto:latest
 ```
 
 #### Option 2: Generic Mosquitto broker
@@ -95,5 +95,5 @@ topic iotdevice-1/type/+/id/# out 1 "" ""
 Start the container:
 
 ```
-docker run --restart=always -d -t --net=host --read-only -v /home/linaro/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-arm64
+docker run --restart=always -d -t --net=host --read-only -v /home/linaro/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest
 ```

--- a/bt-joiner/README.md
+++ b/bt-joiner/README.md
@@ -30,20 +30,6 @@ docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/v
 
 ## Run the pre-built container
 
-AMD64:
-
 ```
-docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/var/run --tmpfs=/var/lock --tmpfs=/var/log --name bt-joiner linarotechnologies/bt-joiner
-```
-
-ARM64:
-
-```
-docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/var/run --tmpfs=/var/lock --tmpfs=/var/log --name bt-joiner linarotechnologies/bt-joiner:latest-arm64
-```
-
-ARMHF:
-
-```
-docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/var/run --tmpfs=/var/lock --tmpfs=/var/log --name bt-joiner linarotechnologies/bt-joiner:latest-armhf
+docker run --restart=always -d -t --privileged --net=host --read-only --tmpfs=/var/run --tmpfs=/var/lock --tmpfs=/var/log --name bt-joiner linarotechnologies/bt-joiner:latest
 ```

--- a/bt-joiner/manifest.yaml
+++ b/bt-joiner/manifest.yaml
@@ -1,0 +1,19 @@
+image: linarotechnologies/bt-joiner:latest
+manifests:
+  -
+    image: linarotechnologies/bt-joiner:latest-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: linarotechnologies/bt-joiner:latest-armhf
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: linarotechnologies/bt-joiner:latest
+    platform:
+      architecture: amd64
+      features:
+        - sse
+      os: linux

--- a/ibm-bluemix-mosquitto/README.md
+++ b/ibm-bluemix-mosquitto/README.md
@@ -26,20 +26,6 @@ docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix
 
 ## Run the pre-built container
 
-AMD64:
-
 ```
-docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix-mosquitto.env --name ibm-bluemix-mosquitto linarotechnologies/ibm-bluemix-mosquitto
-```
-
-ARM64:
-
-```
-docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix-mosquitto.env --name ibm-bluemix-mosquitto linarotechnologies/ibm-bluemix-mosquitto:latest-arm64
-```
-
-ARMHF:
-
-```
-docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix-mosquitto.env --name ibm-bluemix-mosquitto linarotechnologies/ibm-bluemix-mosquitto:latest-armhf
+docker run --restart=always -d -t --net=host --env-file=/home/linaro/ibm-bluemix-mosquitto.env --name ibm-bluemix-mosquitto linarotechnologies/ibm-bluemix-mosquitto:latest
 ```

--- a/ibm-bluemix-mosquitto/manifest.yaml
+++ b/ibm-bluemix-mosquitto/manifest.yaml
@@ -1,0 +1,19 @@
+image: linarotechnologies/ibm-bluemix-mosquitto:latest
+manifests:
+  -
+    image: linarotechnologies/ibm-bluemix-mosquitto:latest-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: linarotechnologies/ibm-bluemix-mosquitto:latest-armhf
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: linarotechnologies/ibm-bluemix-mosquitto:latest
+    platform:
+      architecture: amd64
+      features:
+        - sse
+      os: linux

--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -44,20 +44,6 @@ docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.c
 
 ## Run the pre-built container
 
-AMD64:
-
 ```
-docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto
-```
-
-ARM64:
-
-```
-docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-arm64
-```
-
-ARMHF:
-
-```
-docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest-armhf
+docker run --restart=always -d -t --net=host --read-only -v /path/to/mosquitto.conf:/etc/mosquitto/conf.d/mosquitto.conf --name mosquitto linarotechnologies/mosquitto:latest
 ```

--- a/mosquitto/manifest.yaml
+++ b/mosquitto/manifest.yaml
@@ -1,0 +1,19 @@
+image: linarotechnologies/mosquitto:latest
+manifests:
+  -
+    image: linarotechnologies/mosquitto:latest-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: linarotechnologies/mosquitto:latest-armhf
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: linarotechnologies/mosquitto:latest
+    platform:
+      architecture: amd64
+      features:
+        - sse
+      os: linux

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -63,20 +63,6 @@ docker run --restart=always -d -t --net=host -v /path/to/nginx-lwm2m.conf:/etc/n
 
 ## Run the pre-built container
 
-AMD64:
-
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --add-host=gitci.com:<lwm2m server ip address> -v /path/to/nginx-lwm2m.conf:/etc/nginx/nginx.conf --name nginx linarotechnologies/bt-joiner
-```
-
-ARM64:
-
-```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --add-host=gitci.com:<lwm2m server ip address> -v /path/to/nginx-lwm2m.conf:/etc/nginx/nginx.conf --name nginx linarotechnologies/nginx:latest-arm64
-```
-
-ARMHF:
-
-```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --add-host=gitci.com:<lwm2m server ip address> -v /path/to/nginx-lwm2m.conf:/etc/nginx/nginx.conf --name nginx linarotechnologies/nginx:latest-armhf
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --add-host=gitci.com:<lwm2m server ip address> -v /path/to/nginx-lwm2m.conf:/etc/nginx/nginx.conf --name nginx linarotechnologies/nginx:latest
 ```

--- a/nginx/manifest.yaml
+++ b/nginx/manifest.yaml
@@ -1,0 +1,19 @@
+image: linarotechnologies/nginx:latest
+manifests:
+  -
+    image: linarotechnologies/nginx:latest-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: linarotechnologies/nginx:latest-armhf
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: linarotechnologies/nginx:latest
+    platform:
+      architecture: amd64
+      features:
+        - sse
+      os: linux

--- a/tinyproxy/README.md
+++ b/tinyproxy/README.md
@@ -14,20 +14,6 @@ docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpf
 
 ## Run the pre-built container
 
-AMD64:
-
 ```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy
-```
-
-ARM64:
-
-```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest-arm64
-```
-
-ARMHF:
-
-```
-docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest-armhf
+docker run --restart=always -d -t --net=host --read-only --tmpfs=/var/run --tmpfs=/var/log --tmpfs=/tmp --add-host=gitci.com:<hawkbit ip address> --name tinyproxy linarotechnologies/tinyproxy:latest
 ```

--- a/tinyproxy/manifest.yaml
+++ b/tinyproxy/manifest.yaml
@@ -1,0 +1,19 @@
+image: linarotechnologies/tinyproxy:latest
+manifests:
+  -
+    image: linarotechnologies/tinyproxy:latest-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: linarotechnologies/tinyproxy:latest-armhf
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: linarotechnologies/tinyproxy:latest
+    platform:
+      architecture: amd64
+      features:
+        - sse
+      os: linux


### PR DESCRIPTION
Here is an RFC series which provides a basic docker image manifest for each container. These manifest will be pushed during the CI build, so we can easily update them to provide new architecture support.

Where this gets interesting, is we can do the same thing with our base images, i.e. minideb, alpine. This will allow a follow up series to consolidate the architecture specific Dockerfiles in each project, into a single Dockerfile. We will still have to build for amd64, arm64, and armhf as we do today, but I think this improves the user experience a bit.

If we decide we want to take this route, we'd also need to update the official docs. The good news is that we are going to retain the same tagging scheme, so all the commands we have documented will still work as they do today.