### PR TITLE
bt-joiner: also install bluez-btmon and bluez-meshctl

### DIFF
--- a/bt-joiner/Dockerfile
+++ b/bt-joiner/Dockerfile
@@ -1,6 +1,6 @@
 FROM linarotechnologies/alpine:edge
 
-RUN apk add --no-cache bluez py-dbus py-gobject3
+RUN apk add --no-cache bluez bluez-btmon bluez-meshctl py-dbus py-gobject3
 
 # BT 6lowpan joiner
 RUN mkdir -p /etc/bluetooth/6lowpand/


### PR DESCRIPTION
Useful for debugging and to interact with bluetooth mesh networks.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>